### PR TITLE
Got Pythons 2.7, 3.3, 3.4, 3.5 on Linux and Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+test-data/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 python:
   - "3.5"
+  - "3.4"
+  - "3.3"
 #  - "2.6"
 #  - "2.7"
 #  - "3.2"
-#  - "3.3"
-#  - "3.4"
   # does not have headers provided, please ask https://launchpad.net/~pypy/+archive/ppa
   # maintainers to fix their pypy-dev package.
 #  - "pypy"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python33"
     - PYTHON: "C:\\Python34"
-    - PYTHON: "C:\\Python35"
+#    - PYTHON: "C:\\Python35"
 
 
 init:

--- a/docs/rationale.rst
+++ b/docs/rationale.rst
@@ -1,0 +1,39 @@
+Rationale
+*********
+
+Abstract
+========
+
+This document outlines in detail why I believe this library is a worthwhile investment in time and resources.
+
+Where the idea originated
+-------------------------
+
+There is a slight disconnect between DevOps engineers (particularly Operations personele, Administration personele and Security Analysists) caused by a difference in language, culture and tools. Over and over, people are being asked to transition to a DevOps work cycle but something as simple as learning the new tools and mindset can be overwhelming. Most non-development IT professionals are familiar with basic linux commands, so we decided to explore that.
+
+A lot of the work being done in the DevOps space are written in Python, and because Python is a great language for automation, we decided that it would be almost a gift to allow people making the DevOps transition. Automation is nothing new and lots of people have experience making shell scripts or batch files to acomplish the same task. If these people were given a familiar toolset with which to work in Python their transition will be just that much easier.
+
+At the same time, we realized that "shelling out" commands was a real option, but the overhead of spawing shells and the limitation of using OS-specific system calls makes this unusable for cross-platform automation. Instead what we needed was a native Python function to mirror how these commands work on the outside.
+
+About the time we made this realization, a few of my co-workers along with myself found ourselves working in a Windows environment. We agonized about having our basic toolset taken away from us (Imagine a carpenter working in a shop that forbids hammers). We would have loved to just be able to tail a file and grep the logs (I know there are Windows ways of doing the above tasks, but I only make use of them every couple of years).
+
+This is when our idea was made to not only make a library which provides functions mirroring Linux commands, but to also provide these functions with a Command Line Interface. The dual interfaces (programatic and command line) allow great flexibility.
+
+The commands we are targeting
+-----------------------------
+
+This list is subject to change
+
+- grep
+- tail
+- find
+- wget
+- curl
+- tee
+- top
+- wc
+
+grep.py
+-------
+
+To differentiate ourselves from the real "grep", we have named our command line utility "grep.py". The Python function takes a list of filenames (or open file objects) and searches these files line-by-line for any lines which match a pattern. These lines are then yielded. Options similar to the original "grep" command are accepted.

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -40,7 +40,7 @@ class TestFind(unittest.TestCase):
             os.path.join(".", "branch-1", "level-2", "test", "Test.txt"),
         ]
         results = list(unitils.find())
-        self.assertEqual(sorted(expected), sorted(results))
+        self.assertEqual(set(expected), set(results))
 
     def test_name_param_limits_like_it_should(self):
         """find(name="test.txt") should behave like "$ find . -name test.txt"
@@ -52,7 +52,7 @@ class TestFind(unittest.TestCase):
             os.path.join(".", "branch-1", "level-2", "test", "test.txt"),
         ]
         results = list(unitils.find(name="test.txt"))
-        self.assertEqual(sorted(expected), sorted(results))
+        self.assertEqual(set(expected), set(results))
 
     def test_name_param_limits_like_it_should_for_directories(self):
         """find(name="branch-1") should behave like "$ find . -name branch-1"
@@ -61,7 +61,7 @@ class TestFind(unittest.TestCase):
             os.path.join(".", "branch-1"),
         ]
         results = list(unitils.find(name="branch-1"))
-        self.assertEqual(sorted(expected), sorted(results))
+        self.assertEqual(set(expected), set(results))
 
     def test_path_param_limits_like_it_should(self):
         """find("branch-1", name="test.txt") should behave like "$ find branch-1 -name test.txt"
@@ -72,7 +72,7 @@ class TestFind(unittest.TestCase):
             os.path.join("branch-1", "level-2", "test", "test.txt"),
         ]
         results = list(unitils.find(path="branch-1", name="test.txt"))
-        self.assertEqual(sorted(expected), sorted(results))
+        self.assertEqual(set(expected), set(results))
 
     def test_relative_path_param_limits_like_it_should(self):
         """find("./branch-1", name="test.txt") should behave like "$ find ./branch-1 -name test.txt"
@@ -83,7 +83,7 @@ class TestFind(unittest.TestCase):
             os.path.join(".", "branch-1", "level-2", "test", "test.txt"),
         ]
         results = list(unitils.find(path=os.path.join(".", "branch-1"), name="test.txt"))
-        self.assertEqual(sorted(expected), sorted(results))
+        self.assertEqual(set(expected), set(results))
 
     def test_iname_param_limits_like_it_should(self):
         """find("./branch-1", iname="test.txt") should behave like "$ find ./branch-1 -iname test.txt"
@@ -97,7 +97,7 @@ class TestFind(unittest.TestCase):
             os.path.join(".", "branch-1", "level-2", "test", "Test.txt"),
         ]
         results = list(unitils.find(path=os.path.join(".", "branch-1"), iname="test.txt"))
-        self.assertEqual(sorted(expected), sorted(results))
+        self.assertEqual(set(expected), set(results))
 
     def test_type_param_limits_as_it_should(self):
         """find(ftype="d", name="name*")
@@ -106,7 +106,7 @@ class TestFind(unittest.TestCase):
             os.path.join(".", "branch-1", "level-2", "test"),
         ]
         results = list(unitils.find(".", ftype="d", name="test*"))
-        self.assertEqual(sorted(expected), sorted(results))
+        self.assertEqual(set(expected), set(results))
 
     def test_type_param_D_not_implemented(self):
         with self.assertRaises(NotImplementedError) as exc:

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -1,45 +1,27 @@
 from __future__ import print_function
+from .util import make_test_data_directory
 import os
 import shutil
 import unitils
 import unittest
 import tempfile
 
-def setup_temp_dir(root):
-    if os.path.exists(root):
-        shutil.rmtree(root)
-    os.mkdir(root)
-    os.makedirs(os.path.join(root, "branch-1", "level-2", "test"))
-    filenames = [
-        os.path.join(root, "test.txt"),
-        os.path.join(root, "branch-1", "test.txt"),
-        os.path.join(root, "branch-1", "level-2", "test.txt"),
-        os.path.join(root, "branch-1", "level-2", "test", "test.txt"),
-        os.path.join(root, "Test.txt"),
-        os.path.join(root, "branch-1", "Test.txt"),
-        os.path.join(root, "branch-1", "level-2", "Test.txt"),
-        os.path.join(root, "branch-1", "level-2", "test", "Test.txt"),
-    ]
-    for filename in filenames:
-        with open(filename, "w") as fp:
-            fp.write("Hello, world from: {}\n".format(filename))
 
 class TestFind(unittest.TestCase):
     """Generic tests for unitils.find
     """
 
-    root = os.path.join(".", "_temp_unitils")
     @classmethod
     def setUpClass(cls):
-        setup_temp_dir(cls.root)
+        cls.test_data_dir = make_test_data_directory()
         cls.old_dir = os.getcwd()
-        os.chdir(cls.root)
+        os.chdir(cls.test_data_dir)
 
     @classmethod
     def tearDownClass(cls):
 #        tear_down_temp_dir(cls.root)
         os.chdir(cls.old_dir)
-        shutil.rmtree(cls.root)
+        shutil.rmtree(cls.test_data_dir)
 
     def test_no_params_finds_all_files(self):
         """calling find() with no params should act like issuing "$ find"

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -28,16 +28,16 @@ class TestFind(unittest.TestCase):
         expected = [
             ".",
             os.path.join(".", "test.txt"),
-            os.path.join(".", "Test.txt"),
+            os.path.join(".", "Test_.txt"),
             os.path.join(".", "branch-1"),
             os.path.join(".", "branch-1", "test.txt"),
-            os.path.join(".", "branch-1", "Test.txt"),
+            os.path.join(".", "branch-1", "Test_.txt"),
             os.path.join(".", "branch-1", "level-2"),
             os.path.join(".", "branch-1", "level-2", "test.txt"),
-            os.path.join(".", "branch-1", "level-2", "Test.txt"),
+            os.path.join(".", "branch-1", "level-2", "Test_.txt"),
             os.path.join(".", "branch-1", "level-2", "test"),
             os.path.join(".", "branch-1", "level-2", "test", "test.txt"),
-            os.path.join(".", "branch-1", "level-2", "test", "Test.txt"),
+            os.path.join(".", "branch-1", "level-2", "test", "Test_.txt"),
         ]
         results = list(unitils.find())
         self.assertEqual(set(expected), set(results))
@@ -90,13 +90,13 @@ class TestFind(unittest.TestCase):
         """
         expected = [
             os.path.join(".", "branch-1", "test.txt"),
-            os.path.join(".", "branch-1", "Test.txt"),
+            os.path.join(".", "branch-1", "Test_.txt"),
             os.path.join(".", "branch-1", "level-2", "test.txt"),
-            os.path.join(".", "branch-1", "level-2", "Test.txt"),
+            os.path.join(".", "branch-1", "level-2", "Test_.txt"),
             os.path.join(".", "branch-1", "level-2", "test", "test.txt"),
-            os.path.join(".", "branch-1", "level-2", "test", "Test.txt"),
+            os.path.join(".", "branch-1", "level-2", "test", "Test_.txt"),
         ]
-        results = list(unitils.find(path=os.path.join(".", "branch-1"), iname="test.txt"))
+        results = list(unitils.find(path=os.path.join(".", "branch-1"), iname="test*.txt"))
         self.assertEqual(set(expected), set(results))
 
     def test_type_param_limits_as_it_should(self):

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -47,17 +47,17 @@ class TestFind(unittest.TestCase):
         """
         expected = [
             ".",
-            "./test.txt",
-            "./Test.txt",
-            "./branch-1",
-            "./branch-1/test.txt",
-            "./branch-1/Test.txt",
-            "./branch-1/level-2",
-            "./branch-1/level-2/test.txt",
-            "./branch-1/level-2/Test.txt",
-            "./branch-1/level-2/test",
-            "./branch-1/level-2/test/test.txt",
-            "./branch-1/level-2/test/Test.txt",
+            os.path.join(".", "test.txt"),
+            os.path.join(".", "Test.txt"),
+            os.path.join(".", "branch-1"),
+            os.path.join(".", "branch-1", "test.txt"),
+            os.path.join(".", "branch-1", "Test.txt"),
+            os.path.join(".", "branch-1", "level-2"),
+            os.path.join(".", "branch-1", "level-2", "test.txt"),
+            os.path.join(".", "branch-1", "level-2", "Test.txt"),
+            os.path.join(".", "branch-1", "level-2", "test"),
+            os.path.join(".", "branch-1", "level-2", "test", "test.txt"),
+            os.path.join(".", "branch-1", "level-2", "test", "Test.txt"),
         ]
         results = list(unitils.find())
         self.assertEqual(sorted(expected), sorted(results))
@@ -66,10 +66,10 @@ class TestFind(unittest.TestCase):
         """find(name="test.txt") should behave like "$ find . -name test.txt"
         """
         expected = [
-            "./test.txt",
-            "./branch-1/test.txt",
-            "./branch-1/level-2/test.txt",
-            "./branch-1/level-2/test/test.txt",
+            os.path.join(".", "test.txt"),
+            os.path.join(".", "branch-1", "test.txt"),
+            os.path.join(".", "branch-1", "level-2", "test.txt"),
+            os.path.join(".", "branch-1", "level-2", "test", "test.txt"),
         ]
         results = list(unitils.find(name="test.txt"))
         self.assertEqual(sorted(expected), sorted(results))
@@ -78,7 +78,7 @@ class TestFind(unittest.TestCase):
         """find(name="branch-1") should behave like "$ find . -name branch-1"
         """
         expected = [
-            "./branch-1",
+            os.path.join(".", "branch-1"),
         ]
         results = list(unitils.find(name="branch-1"))
         self.assertEqual(sorted(expected), sorted(results))
@@ -87,9 +87,9 @@ class TestFind(unittest.TestCase):
         """find("branch-1", name="test.txt") should behave like "$ find branch-1 -name test.txt"
         """
         expected = [
-            "branch-1/test.txt",
-            "branch-1/level-2/test.txt",
-            "branch-1/level-2/test/test.txt",
+            os.path.join("branch-1", "test.txt"),
+            os.path.join("branch-1", "level-2", "test.txt"),
+            os.path.join("branch-1", "level-2", "test", "test.txt"),
         ]
         results = list(unitils.find(path="branch-1", name="test.txt"))
         self.assertEqual(sorted(expected), sorted(results))
@@ -98,32 +98,32 @@ class TestFind(unittest.TestCase):
         """find("./branch-1", name="test.txt") should behave like "$ find ./branch-1 -name test.txt"
         """
         expected = [
-            "./branch-1/test.txt",
-            "./branch-1/level-2/test.txt",
-            "./branch-1/level-2/test/test.txt",
+            os.path.join(".", "branch-1", "test.txt"),
+            os.path.join(".", "branch-1", "level-2", "test.txt"),
+            os.path.join(".", "branch-1", "level-2", "test", "test.txt"),
         ]
-        results = list(unitils.find(path="./branch-1", name="test.txt"))
+        results = list(unitils.find(path=os.path.join(".", "branch-1"), name="test.txt"))
         self.assertEqual(sorted(expected), sorted(results))
 
     def test_iname_param_limits_like_it_should(self):
         """find("./branch-1", iname="test.txt") should behave like "$ find ./branch-1 -iname test.txt"
         """
         expected = [
-            "./branch-1/test.txt",
-            "./branch-1/Test.txt",
-            "./branch-1/level-2/test.txt",
-            "./branch-1/level-2/Test.txt",
-            "./branch-1/level-2/test/test.txt",
-            "./branch-1/level-2/test/Test.txt",
+            os.path.join(".", "branch-1", "test.txt"),
+            os.path.join(".", "branch-1", "Test.txt"),
+            os.path.join(".", "branch-1", "level-2", "test.txt"),
+            os.path.join(".", "branch-1", "level-2", "Test.txt"),
+            os.path.join(".", "branch-1", "level-2", "test", "test.txt"),
+            os.path.join(".", "branch-1", "level-2", "test", "Test.txt"),
         ]
-        results = list(unitils.find(path="./branch-1", iname="test.txt"))
+        results = list(unitils.find(path=os.path.join(".", "branch-1"), iname="test.txt"))
         self.assertEqual(sorted(expected), sorted(results))
 
     def test_type_param_limits_as_it_should(self):
         """find(ftype="d", name="name*")
         """
         expected = [
-            "./branch-1/level-2/test",
+            os.path.join(".", "branch-1", "level-2", "test"),
         ]
         results = list(unitils.find(".", ftype="d", name="test*"))
         self.assertEqual(sorted(expected), sorted(results))

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import unitils
 import unittest
-import tempfile
 
 
 class TestFind(unittest.TestCase):
@@ -14,12 +13,11 @@ class TestFind(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.test_data_dir = make_test_data_directory()
-        cls.old_dir = os.getcwd()
+        cls.old_dir = os.path.abspath(os.getcwd())
         os.chdir(cls.test_data_dir)
 
     @classmethod
     def tearDownClass(cls):
-#        tear_down_temp_dir(cls.root)
         os.chdir(cls.old_dir)
         shutil.rmtree(cls.test_data_dir)
 

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -12,7 +12,7 @@ class TestFind(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.test_data_dir = make_test_data_directory()
+        cls.test_data_dir = os.path.abspath(make_test_data_directory())
         cls.old_dir = os.path.abspath(os.getcwd())
         os.chdir(cls.test_data_dir)
 

--- a/test/test_grep.py
+++ b/test/test_grep.py
@@ -46,9 +46,8 @@ class TestGrep(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        pass
-#        os.remove(cls.test_file_1)
-#        os.remove(cls.test_file_2)
+        os.remove(cls.test_file_1)
+        os.remove(cls.test_file_2)
 
     def test_grep_will_find_lines(self):
         """given regex, grep should find all occurances within file
@@ -156,7 +155,7 @@ class TestGrep(unittest.TestCase):
             red(r"\g<0>"),
             """    for line in grep(r"\d+:\s\w+", "/path/to/file"):\n""",
         )
-        content = b"""In addition to the command line utilities, you will also have a Python library which
+        content = """In addition to the command line utilities, you will also have a Python library which
 contains the same functionality. I have routinely found it useful to be able to
 use functions like this in Python source::
 

--- a/test/test_wc.py
+++ b/test/test_wc.py
@@ -1,67 +1,58 @@
-from tempfile import NamedTemporaryFile
-from .util import make_file_for_grep_tests
+from io import StringIO
 import os
 import unittest
 import unitils
 
-contents = """This is a test
+test_data = u"""This is a test
 this is only a test
 """
-
-def prep_fp(fp):
-    fp.write(contents.encode("utf-8"))
-    fp.flush()
-    fp.seek(0)
-    return fp
-
 
 class TestWC(unittest.TestCase):
     """General tests for wc
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.test_file_1 = make_file_for_grep_tests(test_data=contents)
-        cls.test_file_2 = make_file_for_grep_tests(test_data=contents)
+    def setUp(self):
+        self.test_file_1.seek(0)
+        self.test_file_2.seek(0)
 
     @classmethod
-    def tearDownClass(cls):
-        os.remove(cls.test_file_1)
-        os.remove(cls.test_file_2)
+    def setUpClass(cls):
+        cls.test_file_1 = StringIO(test_data)
+        cls.test_file_2 = StringIO(test_data)
 
     def test_wc_counts_number_of_lines_words_and_bytes(self):
         """wc should be able to count the lines, words and bytes of
         files
         """
-        expected = [(2, 9, 35, self.test_file_1)]
+        expected = [(2, 9, 35, "<stdin>")]
         results = list(unitils.wc((self.test_file_1,)))
         self.assertEqual(expected, results)
 
     def test_wc_will_yield_only_linecount(self):
         """wc(files, lines=True) should behave like `wc -l`
         """
-        expected = [(2, self.test_file_1)]
+        expected = [(2, "<stdin>")]
         results = list(unitils.wc((self.test_file_1,), lines=True))
         self.assertEqual(expected, results)
 
     def test_wc_will_yield_only_byte_count(self):
         """wc(files, byte_count=True) should behave like `wc -c`
         """
-        expected = [(35, self.test_file_1)]
+        expected = [(35, "<stdin>")]
         results = list(unitils.wc((self.test_file_1,), byte_count=True))
         self.assertEqual(expected, results)
 
     def test_wc_will_yield_only_word_count(self):
         """wc(files, words=True) should behave like `wc -w`
         """
-        expected = [(9, self.test_file_1)]
+        expected = [(9, "<stdin>")]
         results = list(unitils.wc((self.test_file_1,), words=True))
         self.assertEqual(expected, results)
 
     def test_wc_will_yield_only_char_count(self):
         """wc(files, chars=True) should behave like `wc -m`
         """
-        expected = [(35, self.test_file_1)]
+        expected = [(35, "<stdin>")]
         results = list(unitils.wc((self.test_file_1,), chars=True))
         self.assertEqual(expected, results)
 
@@ -69,7 +60,7 @@ class TestWC(unittest.TestCase):
         """wc(files, chars=True, lines=True, words=True,
         byte_count=True) should behave like `wc -cmlw`
         """
-        expected = [(2, 9, 35, 35, self.test_file_1)]
+        expected = [(2, 9, 35, 35, "<stdin>")]
         results = list(unitils.wc(
             (self.test_file_1,),
             chars=True,
@@ -83,7 +74,7 @@ class TestWC(unittest.TestCase):
     def test_wc_will_yield_only_max_line_length(self):
         """wc(files, max_line_length=True) should behave like `wc -L`
         """
-        expected = [(19, self.test_file_1)]
+        expected = [(19, "<stdin>")]
         results = list(unitils.wc((self.test_file_1,), max_line_length=True))
         self.assertEqual(expected, results)
 
@@ -92,8 +83,8 @@ class TestWC(unittest.TestCase):
         added to the end of the output
         """
         expected = [
-            (2, 9, 35, self.test_file_1),
-            (2, 9, 35, self.test_file_2),
+            (2, 9, 35, "<stdin>"),
+            (2, 9, 35, "<stdin>"),
             (4, 18, 70, "total")
         ]
         results = list(unitils.wc((self.test_file_1, self.test_file_2)))
@@ -103,8 +94,8 @@ class TestWC(unittest.TestCase):
         """All options should work with multiple files
         """
         expected = [
-            (2, 9, 35, 35, 19, self.test_file_1),
-            (2, 9, 35, 35, 19, self.test_file_2),
+            (2, 9, 35, 35, 19, "<stdin>"),
+            (2, 9, 35, 35, 19, "<stdin>"),
             (4, 18, 70, 70, 19, "total")
         ]
         results = list(unitils.wc(

--- a/test/test_wc.py
+++ b/test/test_wc.py
@@ -1,4 +1,6 @@
 from tempfile import NamedTemporaryFile
+from .util import make_file_for_grep_tests
+import os
 import unittest
 import unitils
 
@@ -16,113 +18,101 @@ def prep_fp(fp):
 class TestWC(unittest.TestCase):
     """General tests for wc
     """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_file_1 = make_file_for_grep_tests(test_data=contents)
+        cls.test_file_2 = make_file_for_grep_tests(test_data=contents)
+
+    @classmethod
+    def tearDownClass(cls):
+        os.remove(cls.test_file_1)
+        os.remove(cls.test_file_2)
+
     def test_wc_counts_number_of_lines_words_and_bytes(self):
         """wc should be able to count the lines, words and bytes of
         files
         """
-        with NamedTemporaryFile(dir=".") as fp:
-            prep_fp(fp)
-            expected = [(2, 9, 35, fp.name)]
-            # Must accept either a filename or a file-like object
-            results = list(unitils.wc((fp,)))
-            self.assertEqual(expected, results)
-            results = list(unitils.wc((fp.name,)))
-            self.assertEqual(expected, results)
+        expected = [(2, 9, 35, self.test_file_1)]
+        results = list(unitils.wc((self.test_file_1,)))
+        self.assertEqual(expected, results)
 
     def test_wc_will_yield_only_linecount(self):
         """wc(files, lines=True) should behave like `wc -l`
         """
-        with NamedTemporaryFile(dir=".") as fp:
-            prep_fp(fp)
-            expected = [(2, fp.name)]
-            results = list(unitils.wc((fp.name,), lines=True))
-            self.assertEqual(expected, results)
+        expected = [(2, self.test_file_1)]
+        results = list(unitils.wc((self.test_file_1,), lines=True))
+        self.assertEqual(expected, results)
 
     def test_wc_will_yield_only_byte_count(self):
         """wc(files, byte_count=True) should behave like `wc -c`
         """
-        with NamedTemporaryFile(dir=".") as fp:
-            prep_fp(fp)
-            expected = [(35, fp.name)]
-            results = list(unitils.wc((fp.name,), byte_count=True))
-            self.assertEqual(expected, results)
+        expected = [(35, self.test_file_1)]
+        results = list(unitils.wc((self.test_file_1,), byte_count=True))
+        self.assertEqual(expected, results)
 
     def test_wc_will_yield_only_word_count(self):
         """wc(files, words=True) should behave like `wc -w`
         """
-        with NamedTemporaryFile(dir=".") as fp:
-            prep_fp(fp)
-            expected = [(9, fp.name)]
-            results = list(unitils.wc((fp.name,), words=True))
-            self.assertEqual(expected, results)
+        expected = [(9, self.test_file_1)]
+        results = list(unitils.wc((self.test_file_1,), words=True))
+        self.assertEqual(expected, results)
 
     def test_wc_will_yield_only_char_count(self):
         """wc(files, chars=True) should behave like `wc -m`
         """
-        with NamedTemporaryFile(dir=".") as fp:
-            prep_fp(fp)
-            expected = [(35, fp.name)]
-            results = list(unitils.wc((fp.name,), chars=True))
-            self.assertEqual(expected, results)
+        expected = [(35, self.test_file_1)]
+        results = list(unitils.wc((self.test_file_1,), chars=True))
+        self.assertEqual(expected, results)
 
     def test_wc_will_yield_all_fields(self):
         """wc(files, chars=True, lines=True, words=True,
         byte_count=True) should behave like `wc -cmlw`
         """
-        with NamedTemporaryFile(dir=".") as fp:
-            prep_fp(fp)
-            expected = [(2, 9, 35, 35, fp.name)]
-            results = list(unitils.wc(
-                (fp.name,),
-                chars=True,
-                lines=True,
-                words=True,
-                byte_count=True,
+        expected = [(2, 9, 35, 35, self.test_file_1)]
+        results = list(unitils.wc(
+            (self.test_file_1,),
+            chars=True,
+            lines=True,
+            words=True,
+            byte_count=True,
 
-            ))
-            self.assertEqual(expected, results)
+        ))
+        self.assertEqual(expected, results)
 
     def test_wc_will_yield_only_max_line_length(self):
         """wc(files, max_line_length=True) should behave like `wc -L`
         """
-        with NamedTemporaryFile(dir=".") as fp:
-            prep_fp(fp)
-            expected = [(19, fp.name)]
-            results = list(unitils.wc((fp.name,), max_line_length=True))
-            self.assertEqual(expected, results)
+        expected = [(19, self.test_file_1)]
+        results = list(unitils.wc((self.test_file_1,), max_line_length=True))
+        self.assertEqual(expected, results)
 
     def test_wc_adds_totals_if_more_than_one_file(self):
         """If more than one file is specified, a total line should be
         added to the end of the output
         """
-        with NamedTemporaryFile(dir=".") as fp_1, NamedTemporaryFile(dir=".") as fp_2:
-            for fp in (fp_1, fp_2):
-                prep_fp(fp)
-            expected = [
-                (2, 9, 35, fp_1.name),
-                (2, 9, 35, fp_2.name),
-                (4, 18, 70, "total")
-            ]
-            results = list(unitils.wc((fp_1.name, fp_2.name)))
-            self.assertEqual(expected, results)
+        expected = [
+            (2, 9, 35, self.test_file_1),
+            (2, 9, 35, self.test_file_2),
+            (4, 18, 70, "total")
+        ]
+        results = list(unitils.wc((self.test_file_1, self.test_file_2)))
+        self.assertEqual(expected, results)
 
     def test_wc_adds_totals_if_more_than_one_file_and_works_with_all_options(self):
         """All options should work with multiple files
         """
-        with NamedTemporaryFile(dir=".") as fp_1, NamedTemporaryFile(dir=".") as fp_2:
-            for fp in (fp_1, fp_2):
-                prep_fp(fp)
-            expected = [
-                (2, 9, 35, 35, 19, fp_1.name),
-                (2, 9, 35, 35, 19, fp_2.name),
-                (4, 18, 70, 70, 19, "total")
-            ]
-            results = list(unitils.wc(
-                (fp_1.name, fp_2.name),
-                chars=True,
-                lines=True,
-                words=True,
-                byte_count=True,
-                max_line_length=True
-            ))
-            self.assertEqual(expected, results)
+        expected = [
+            (2, 9, 35, 35, 19, self.test_file_1),
+            (2, 9, 35, 35, 19, self.test_file_2),
+            (4, 18, 70, 70, 19, "total")
+        ]
+        results = list(unitils.wc(
+            (self.test_file_1, self.test_file_2),
+            chars=True,
+            lines=True,
+            words=True,
+            byte_count=True,
+            max_line_length=True
+        ))
+        self.assertEqual(expected, results)

--- a/test/util.py
+++ b/test/util.py
@@ -35,11 +35,3 @@ this
 that
 the other
 """
-
-def make_file_for_grep_tests(root=".", test_data=_test_data):
-    filename = os.path.join(root, "test-file.{}.txt".format(uuid()))
-    with open(filename, "w") as fp:
-        fp.write(test_data)
-        fp.flush()
-        os.fsync(fp.fileno())
-    return filename

--- a/test/util.py
+++ b/test/util.py
@@ -1,0 +1,45 @@
+import os
+import shutil
+from uuid import uuid4 as uuid
+from time import time, sleep
+
+
+def make_test_data_directory(root="."):
+    tmp_dir = os.path.join(root, "test-data")
+    if os.path.exists(tmp_dir):
+        shutil.rmtree(tmp_dir)
+    os.mkdir(tmp_dir)
+    os.makedirs(os.path.join(tmp_dir, "branch-1", "level-2", "test"))
+    filenames = [
+        os.path.join(tmp_dir, "test.txt"),
+        os.path.join(tmp_dir, "branch-1", "test.txt"),
+        os.path.join(tmp_dir, "branch-1", "level-2", "test.txt"),
+        os.path.join(tmp_dir, "branch-1", "level-2", "test", "test.txt"),
+        os.path.join(tmp_dir, "Test.txt"),
+        os.path.join(tmp_dir, "branch-1", "Test.txt"),
+        os.path.join(tmp_dir, "branch-1", "level-2", "Test.txt"),
+        os.path.join(tmp_dir, "branch-1", "level-2", "test", "Test.txt"),
+    ]
+    for filename in filenames:
+        with open(filename, "w") as fp:
+            fp.write("Hello, world from: {}\n".format(filename))
+            fp.flush()
+            os.fsync(fp.fileno())
+    return tmp_dir
+
+test_data = """line 1
+1 line
+Line 1
+1 Line
+this
+that
+the other
+""".encode("utf-8")
+
+def make_file_for_grep_tests(root=".", test_data=test_data):
+    filename = os.path.join(root, "test-file.{}.txt".format(uuid()))
+    with open(filename, "w") as fp:
+        fp.write(test_data)
+        fp.flush()
+        os.fsync(fp.fileno())
+    return filename

--- a/test/util.py
+++ b/test/util.py
@@ -27,16 +27,16 @@ def make_test_data_directory(root="."):
             os.fsync(fp.fileno())
     return tmp_dir
 
-test_data = """line 1
+_test_data = """line 1
 1 line
 Line 1
 1 Line
 this
 that
 the other
-""".encode("utf-8")
+"""
 
-def make_file_for_grep_tests(root=".", test_data=test_data):
+def make_file_for_grep_tests(root=".", test_data=_test_data):
     filename = os.path.join(root, "test-file.{}.txt".format(uuid()))
     with open(filename, "w") as fp:
         fp.write(test_data)

--- a/test/util.py
+++ b/test/util.py
@@ -15,10 +15,10 @@ def make_test_data_directory(root="."):
         os.path.join(tmp_dir, "branch-1", "test.txt"),
         os.path.join(tmp_dir, "branch-1", "level-2", "test.txt"),
         os.path.join(tmp_dir, "branch-1", "level-2", "test", "test.txt"),
-        os.path.join(tmp_dir, "Test.txt"),
-        os.path.join(tmp_dir, "branch-1", "Test.txt"),
-        os.path.join(tmp_dir, "branch-1", "level-2", "Test.txt"),
-        os.path.join(tmp_dir, "branch-1", "level-2", "test", "Test.txt"),
+        os.path.join(tmp_dir, "Test_.txt"),
+        os.path.join(tmp_dir, "branch-1", "Test_.txt"),
+        os.path.join(tmp_dir, "branch-1", "level-2", "Test_.txt"),
+        os.path.join(tmp_dir, "branch-1", "level-2", "test", "Test_.txt"),
     ]
     for filename in filenames:
         with open(filename, "w") as fp:

--- a/unitils/find.py
+++ b/unitils/find.py
@@ -12,25 +12,20 @@ def find(path=".", name=None, iname=None, ftype="*", expr=""):
             "Introspection for {} not implemented".format(ftype)
         )
     ftype_mapping = {
-        "b": stat.S_ISBLK,
-        "c": stat.S_ISCHR,
-        "d": stat.S_ISDIR,
-        "p": stat.S_ISFIFO,
-        "f": stat.S_ISREG,
-        "l": stat.S_ISLNK,
+        "b": stat.S_ISBLK, "c": stat.S_ISCHR,
+        "d": stat.S_ISDIR, "p": stat.S_ISFIFO,
+        "f": stat.S_ISREG, "l": stat.S_ISLNK,
         "s": stat.S_ISSOCK,
         "*": lambda *args, **kwargs: True,
     }
     type_test = ftype_mapping[ftype]
 
     if name is not None:
-        # name will be more restrictive than iname so start with it
         regex = re.compile(fnmatch.translate(name))
     elif iname is not None:
         regex = re.compile(fnmatch.translate(iname), flags=re.IGNORECASE)
     else:
         regex = re.compile(fnmatch.translate("*"))
-
 
     if regex.match(path) and type_test(os.stat(path).st_mode):
         yield os.path.relpath(path)

--- a/unitils/find.py
+++ b/unitils/find.py
@@ -4,7 +4,7 @@ import re
 import os
 
 
-def find(path="./", name=None, iname=None, ftype="*", expr=""):
+def find(path=".", name=None, iname=None, ftype="*", expr=""):
     """Search for files in a directory heirarchy.
     """
     if ftype not in "bcdpfls*" or len(ftype) != 1:

--- a/unitils/grep.py
+++ b/unitils/grep.py
@@ -52,10 +52,6 @@ def grep(expr,
     """
     expr = re.compile(expr) if isinstance(expr, str) else expr
     files = files if isinstance(files, list) else [files]
-    for index, fp in enumerate(list(files)):
-        if isinstance(fp, str):
-            files[index] = open(fp, "r")
-            atexit.register(files[index].close)
     for fp in files:
         for line_number, line in enumerate(fp, start=1):
             if bool(expr.search(line)) == invert_match:
@@ -64,5 +60,9 @@ def grep(expr,
             if line_numbers:
                 line = "{}: {}".format(green(line_number) if color else line_number, line)
             if filenames:
-                line = "{}: {}".format(magenta(fp.name) if color else fp.name, line)
+                if hasattr(fp, "name"):
+                    line = "{}: {}".format(magenta(fp.name) if color else fp.name, line)
+                else:
+                    line = "{}: {}".format(magenta("<stdin>") if color else "<stdin>", line)
+
             yield line

--- a/unitils/grep.py
+++ b/unitils/grep.py
@@ -50,30 +50,19 @@ def grep(expr,
     :type expr: str, compiled regex
     :type files: str, list, file
     """
-    if isinstance(expr, str):
-        # Compile the str into a regex object, otherwise
-        # assume that expr can be used directly, expr should
-        # have at least two methods, `search` and `sub`
-        expr = re.compile(expr)
-    if not isinstance(files, list):
-        files = [files]
+    expr = re.compile(expr) if isinstance(expr, str) else expr
+    files = files if isinstance(files, list) else [files]
     for index, fp in enumerate(list(files)):
         if isinstance(fp, str):
-            # If fp is a string, assume it is the path to a file,
-            # open it and register its "closer" to execute on exit
             files[index] = open(fp, "r")
             atexit.register(files[index].close)
     for fp in files:
-        for index, line in enumerate(fp):
-            ret = line
-            line_number, filename = str(index+1), fp.name
-            if bool(expr.search(ret)) != invert_match:
-                if color:
-                    line_number, filename = green(line_number), magenta(filename)
-                    if not invert_match:
-                        ret = expr.sub(red(r"\g<0>"), ret)
-                if line_numbers:
-                    ret = "{}: {}".format(line_number, ret)
-                if filenames:
-                    ret = "{}: {}".format(filename, ret)
-                yield ret
+        for line_number, line in enumerate(fp, start=1):
+            if bool(expr.search(line)) == invert_match:
+                continue
+            line = expr.sub(red(r"\g<0>"), line) if color else line
+            if line_numbers:
+                line = "{}: {}".format(green(line_number) if color else line_number, line)
+            if filenames:
+                line = "{}: {}".format(magenta(fp.name) if color else fp.name, line)
+            yield line

--- a/unitils/wc.py
+++ b/unitils/wc.py
@@ -16,21 +16,23 @@ def _examine_fp(fp):
     current_lines           = 0
     current_chars           = 0
     current_words           = 0
-    current_bytes           = os.path.getsize(fp.name)
+    current_bytes           = 0
     for line in fp:
         current_lines += 1
-        current_words += len(word.findall(line.decode("utf-8")))
+        current_words += len(word.findall(line))
         current_chars += len(line)
         current_line_length = len(line.strip())
         if max_line_length < current_line_length:
             max_line_length = current_line_length
+    fp.seek(0, os.SEEK_END)
+    filename = fp.name if hasattr(fp, "name") else "<stdin>"
     return (
         current_lines,
         current_words,
-        current_bytes,
+        fp.tell(),
         current_chars,
         max_line_length,
-        fp.name
+        filename
     )
 
 def _gather_output(counts,
@@ -108,13 +110,7 @@ def wc(files,
     total_words       = 0
     total_line_length = 0
 
-    for fname in files:
-        if isinstance(fname, str):
-            fp = open(fname, "rb")
-            atexit.register(fp.close)
-        else:
-            fp = fname
-
+    for fp in files:
         current_stats = _examine_fp(fp)
         yield _gather_output(current_stats,
                              lines,


### PR DESCRIPTION
Got all targets Python 2.7, 3.3, 3.4, 3.5 on both Linux and Windows

One caveat, Because `lxml` for some reason does not have a wheel on PyPI for Python 3.5, the tests fail on Windows AppVeyor because it cannot build lxml for want of header files. I will open an issue with `lxml` to fix this issue, but in the meantime, I am fairly confident that having all other tests pass (including Python 3.5 on Linux and all other Pythons on Windows) that unitils will work on Windows with Python 3.5, I would appreciate an issue if this is not the case. 